### PR TITLE
fix: Landing page - remove HMAC reference

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -341,9 +341,9 @@
       <p>Extract consistency keys from event payloads. Events stay pure business data.</p>
     </div>
     <div class="feature">
-      <div class="feature-icon">🔐</div>
-      <h3>HMAC Tokens</h3>
-      <p>Tamper-proof consistency tokens with HMAC-SHA256 signatures.</p>
+      <div class="feature-icon">🎟️</div>
+      <h3>Simple Tokens</h3>
+      <p>Lightweight Base64 tokens — or pass conditions directly. Your choice.</p>
     </div>
     <div class="feature">
       <div class="feature-icon">⚡</div>


### PR DESCRIPTION
Updates landing page feature section:

- "HMAC Tokens" → "Simple Tokens"
- "Tamper-proof consistency tokens with HMAC-SHA256 signatures" → "Lightweight Base64 tokens — or pass conditions directly"

Missed in PR #9.