### PR TITLE
fix: decide() takes state instead of events

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ const result = await store.read<CartEvent>({
 const state = evolve(result.events, cartDecider);
 
 // 3. Decide: command + state → new events
-const newEvents = decide(command, result.events, cartDecider);
+const newEvents = decide(command, state, cartDecider);
 
 // 4. Append with consistency check
 await store.append(newEvents, result.appendCondition);
@@ -485,7 +485,7 @@ await store.append(newEvents, result.appendCondition);
 | Function | Description |
 |----------|-------------|
 | `evolve(events, decider)` | Fold events into state |
-| `decide(command, events, decider)` | Build state + decide → new events |
+| `decide(command, state, decider)` | Execute command against state → new events |
 
 ## API Reference
 

--- a/src/decider.ts
+++ b/src/decider.ts
@@ -99,23 +99,22 @@ export function evolve<State, Command, E extends Event>(
 }
 
 /**
- * Execute a command against a decider, given the current events.
- * Builds state from events, then calls decider.decide().
+ * Execute a command against a decider with the current state.
  * Returns the new events that should be appended.
  * 
  * @example
  * ```typescript
  * const result = await store.read<CartEvent>({ conditions });
- * const newEvents = decide(command, result.events, cartDecider);
- * await store.append(newEvents, result.token);
+ * const state = evolve(result.events, cartDecider);
+ * const newEvents = decide(command, state, cartDecider);
+ * await store.append(newEvents, result.appendCondition);
  * ```
  */
 export function decide<State, Command, E extends Event>(
   command: Command,
-  events: readonly (E | StoredEvent<E>)[],
+  state: State,
   decider: Decider<State, Command, E>
 ): E[] {
-  const state = evolve(events, decider);
   const result = decider.decide(command, state);
   return Array.isArray(result) ? result : [result];
 }

--- a/test/decider.test.ts
+++ b/test/decider.test.ts
@@ -104,24 +104,25 @@ describe('Decider', () => {
   });
 
   describe('decide', () => {
-    it('produces events from command', () => {
-      const events: CartEvent[] = [];
+    it('produces events from command and state', () => {
+      const state = cartDecider.initialState();
       const command: CartCommand = { type: 'AddItem', productId: 'apple', quantity: 3 };
 
-      const newEvents = decide(command, events, cartDecider);
+      const newEvents = decide(command, state, cartDecider);
       
       expect(newEvents).toHaveLength(1);
       expect(newEvents[0].type).toBe('ItemAdded');
       expect(newEvents[0].data).toEqual({ productId: 'apple', quantity: 3 });
     });
 
-    it('considers current state when deciding', () => {
+    it('uses evolved state when deciding', () => {
       const events: CartEvent[] = [
         { type: 'ItemAdded', data: { productId: 'apple', quantity: 1 } },
       ];
+      const state = evolve(events, cartDecider);
       const command: CartCommand = { type: 'Checkout' };
 
-      const newEvents = decide(command, events, cartDecider);
+      const newEvents = decide(command, state, cartDecider);
       
       expect(newEvents).toHaveLength(1);
       expect(newEvents[0].type).toBe('CartCheckedOut');
@@ -133,25 +134,26 @@ describe('Decider', () => {
         { type: 'ItemAdded', data: { productId: 'apple', quantity: 1 } },
         { type: 'CartCheckedOut', data: { itemCount: 1 } },
       ];
+      const state = evolve(events, cartDecider);
       const command: CartCommand = { type: 'AddItem', productId: 'banana', quantity: 1 };
 
-      expect(() => decide(command, events, cartDecider))
+      expect(() => decide(command, state, cartDecider))
         .toThrow('Cart already checked out');
     });
 
     it('throws when checkout on empty cart', () => {
-      const events: CartEvent[] = [];
+      const state = cartDecider.initialState();
       const command: CartCommand = { type: 'Checkout' };
 
-      expect(() => decide(command, events, cartDecider))
+      expect(() => decide(command, state, cartDecider))
         .toThrow('Cart is empty');
     });
 
     it('throws when removing non-existent item', () => {
-      const events: CartEvent[] = [];
+      const state = cartDecider.initialState();
       const command: CartCommand = { type: 'RemoveItem', productId: 'ghost' };
 
-      expect(() => decide(command, events, cartDecider))
+      expect(() => decide(command, state, cartDecider))
         .toThrow('Item not in cart');
     });
   });


### PR DESCRIPTION
Aligns with Emmett's Decider pattern.

**Before:**
```typescript
const state = evolve(events, decider);
const newEvents = decide(command, events, decider); // ❌ events
```

**After:**
```typescript
const state = evolve(events, decider);
const newEvents = decide(command, state, decider); // ✅ state
```

More explicit and flexible — allows state caching/manipulation between evolve and decide.