### PR TITLE
docs: add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Changelog
+
+All notable changes to BoundlessDB will be documented in this file.
+
+## [Unreleased]
+
+### Breaking Changes
+
+#### Removed: Token/Cryptographic Signing
+- Removed `token.ts` and `token.browser.ts`
+- Removed `secret` option from `EventStoreOptions`
+- **Migration:** Use `appendCondition` directly (see below)
+
+#### Removed: Decider Pattern Helpers
+- Removed `src/decider.ts` with `Decider` type, `evolve()` and `decide()` helpers
+- **Migration:** Use plain functions with standard `reduce`:
+  ```typescript
+  // Before
+  const state = evolve(events, decider);
+  const newEvents = decide(command, state, decider);
+  
+  // After
+  const state = events.reduce(evolve, initialState);
+  const newEvents = decide(command, state);
+  ```
+
+#### Changed: Token → AppendCondition
+- `read()` now returns `appendCondition` as a plain object (not encoded token)
+- `append()` accepts `AppendCondition` directly
+- **Migration:**
+  ```typescript
+  // Before
+  const { events, token } = await store.read({ conditions });
+  await store.append(newEvents, token);
+  
+  // After  
+  const { events, appendCondition } = await store.read({ conditions });
+  await store.append(newEvents, appendCondition);
+  ```
+
+### Added
+
+#### QueryResult Class
+- `read()` returns a `QueryResult` with helper methods:
+  - `isEmpty()`, `count`, `first()`, `last()`
+  - `position`, `conditions`, `appendCondition`
+
+#### Typed Events
+- `Event<Type, Payload>` marker type for type-safe events
+- `read<E>()` and `append<E>()` support generics
+
+#### Union Types for QueryCondition
+- `UnconstrainedCondition`: `{ type: 'X' }` — match all events of type
+- `ConstrainedCondition`: `{ type: 'X', key: 'a', value: 'b' }` — match specific key
+- Partial conditions like `{ type: 'X', key: 'a' }` are now TypeScript errors
+
+#### Type Guard
+- `isConstrainedCondition()` exported for storage implementations
+
+#### Fluent Query API
+- Chainable query builder: `store.query<E>()`
+- Methods: `matchType()`, `matchKey()`, `fromPosition()`, `limit()`, `read()`
+  ```typescript
+  const { events, appendCondition } = await store.query<CourseEvent>()
+    .matchType('CourseCreated')
+    .matchKey('StudentSubscribed', 'course', 'cs101')
+    .read();
+  ```
+
+### Changed
+
+- Empty `conditions: []` now returns all events (was: error)
+- `appendCondition` is a plain object: `{ position: bigint, conditions: QueryCondition[] }`
+
+### Documentation
+
+- Landing page redesigned with tabbed code examples
+- README updated to use `decide` pattern
+- Removed npm install section (package not yet published)
+
+## [0.1.0] - 2026-02-20
+
+### Added
+
+- Initial release
+- DCB-inspired Event Store with config-based consistency keys
+- Storage backends: SQLite, PostgreSQL, sql.js (browser), In-Memory
+- Auto-reindex on config change
+- Conflict detection with delta


### PR DESCRIPTION
Documents all breaking changes and additions:

### Breaking Changes
- Token/signing removed → use `appendCondition` directly
- Decider pattern helpers removed → use plain `reduce`
- `token` renamed to `appendCondition`

### Added
- `QueryResult` class with helpers
- Typed events with `Event<Type, Payload>`
- Union types for `QueryCondition`
- `isConstrainedCondition()` type guard

### Documentation
- Landing page redesign
- README with `decide` pattern