### PR TITLE
feat: fluent query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,31 @@ if (result.conflict) {
 }
 ```
 
+## Fluent Query API
+
+Build queries with a chainable API:
+
+```typescript
+const { events, appendCondition } = await store.query<CourseEvent>()
+  .matchType('CourseCreated')                         // all events of type
+  .matchKey('StudentSubscribed', 'course', 'cs101')   // where key = value
+  .fromPosition(100n)                                 // start from position
+  .limit(50)                                          // limit results
+  .read();
+```
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `matchType(type)` | Match all events of type (unconstrained) |
+| `matchKey(type, key, value)` | Match events where key equals value (constrained) |
+| `fromPosition(bigint)` | Start reading from position |
+| `limit(number)` | Limit number of results |
+| `read()` | Execute query, returns `QueryResult` |
+
+The fluent API is equivalent to calling `store.read()` with conditions — use whichever style you prefer.
+
 ## AppendCondition
 
 When you call `read()`, the result contains an `appendCondition` with:

--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -22,6 +22,7 @@ import {
   type QueryCondition,
   type StoredEvent,
 } from './types.js';
+import { QueryBuilder, type QueryExecutor } from './query-builder.js';
 
 /**
  * Recursively sort object keys for deterministic JSON
@@ -119,6 +120,26 @@ export class EventStore {
       const duration = Date.now() - startTime;
       console.log(`[EventStore] ✅ Reindex complete: ${eventCount} events, ${keyCount} keys (${duration}ms)`);
     }
+  }
+
+  /**
+   * Create a fluent query builder.
+   * 
+   * @typeParam E - Event union type for typed results
+   * @returns QueryBuilder for chaining
+   * 
+   * @example
+   * ```typescript
+   * const result = await store.query<CourseEvent>()
+   *   .matchType('CourseCreated')
+   *   .matchKey('StudentSubscribed', 'course', 'cs101')
+   *   .fromPosition(100n)
+   *   .limit(50)
+   *   .read();
+   * ```
+   */
+  query<E extends Event = Event>(): QueryBuilder<E> {
+    return new QueryBuilder<E>(this as unknown as QueryExecutor<E>);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,3 +40,6 @@ export { PostgresStorage } from './storage/postgres.js';
 // Config
 export { KeyExtractor, KeyExtractionError } from './config/extractor.js';
 export { validateConfig, ConfigValidationError } from './config/validator.js';
+
+// Query Builder
+export { QueryBuilder } from './query-builder.js';

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -1,0 +1,97 @@
+/**
+ * Fluent Query Builder for BoundlessDB
+ */
+
+import type { Event, QueryCondition, QueryResult } from './types.js';
+
+export interface QueryExecutor<E extends Event> {
+  read(query: { 
+    conditions: QueryCondition[]; 
+    fromPosition?: bigint; 
+    limit?: number; 
+  }): Promise<QueryResult<E>>;
+}
+
+/**
+ * Fluent API for building queries.
+ * 
+ * @example
+ * ```typescript
+ * const result = await store.query<CourseEvent>()
+ *   .matchType('CourseCreated')
+ *   .matchKey('StudentSubscribed', 'course', 'cs101')
+ *   .fromPosition(100n)
+ *   .limit(50)
+ *   .read();
+ * ```
+ */
+export class QueryBuilder<E extends Event> {
+  private conditions: QueryCondition[] = [];
+  private _fromPosition?: bigint;
+  private _limit?: number;
+
+  constructor(private readonly executor: QueryExecutor<E>) {}
+
+  /**
+   * Add an unconstrained condition (match all events of type).
+   * 
+   * @example
+   * ```typescript
+   * .matchType('CourseCreated')  // matches ALL CourseCreated events
+   * ```
+   */
+  matchType(type: string): this {
+    this.conditions.push({ type });
+    return this;
+  }
+
+  /**
+   * Add a constrained condition (match events where key equals value).
+   * 
+   * @example
+   * ```typescript
+   * .matchKey('StudentSubscribed', 'course', 'cs101')
+   * ```
+   */
+  matchKey(type: string, key: string, value: string): this {
+    this.conditions.push({ type, key, value });
+    return this;
+  }
+
+  /**
+   * Start reading from a specific position.
+   * 
+   * @example
+   * ```typescript
+   * .fromPosition(100n)  // skip events before position 100
+   * ```
+   */
+  fromPosition(position: bigint): this {
+    this._fromPosition = position;
+    return this;
+  }
+
+  /**
+   * Limit the number of events returned.
+   * 
+   * @example
+   * ```typescript
+   * .limit(50)  // return at most 50 events
+   * ```
+   */
+  limit(count: number): this {
+    this._limit = count;
+    return this;
+  }
+
+  /**
+   * Execute the query and return results.
+   */
+  async read(): Promise<QueryResult<E>> {
+    return this.executor.read({
+      conditions: this.conditions,
+      fromPosition: this._fromPosition,
+      limit: this._limit,
+    });
+  }
+}

--- a/test/query-builder.test.ts
+++ b/test/query-builder.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createEventStore, InMemoryStorage, type Event } from '../src/index.js';
+
+type TestEvent = 
+  | Event<'CourseCreated', { courseId: string; capacity: number }>
+  | Event<'StudentSubscribed', { courseId: string; studentId: string }>;
+
+describe('QueryBuilder (Fluent API)', () => {
+  const config = {
+    eventTypes: {
+      CourseCreated: {
+        keys: [{ name: 'course', path: 'data.courseId' }]
+      },
+      StudentSubscribed: {
+        keys: [
+          { name: 'course', path: 'data.courseId' },
+          { name: 'student', path: 'data.studentId' }
+        ]
+      }
+    }
+  };
+
+  let store: ReturnType<typeof createEventStore>;
+
+  beforeEach(async () => {
+    store = createEventStore({
+      storage: new InMemoryStorage(),
+      consistency: config
+    });
+
+    // Seed some events
+    await store.append<TestEvent>([
+      { type: 'CourseCreated', data: { courseId: 'cs101', capacity: 30 } },
+      { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+      { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'bob' } },
+      { type: 'CourseCreated', data: { courseId: 'math201', capacity: 25 } },
+      { type: 'StudentSubscribed', data: { courseId: 'math201', studentId: 'alice' } },
+    ], null);
+  });
+
+  it('should query with matchType (unconstrained)', async () => {
+    const result = await store.query<TestEvent>()
+      .matchType('CourseCreated')
+      .read();
+
+    expect(result.count).toBe(2);
+    expect(result.events.map(e => e.data.courseId)).toEqual(['cs101', 'math201']);
+  });
+
+  it('should query with match (constrained)', async () => {
+    const result = await store.query<TestEvent>()
+      .matchKey('StudentSubscribed', 'course', 'cs101')
+      .read();
+
+    expect(result.count).toBe(2);
+    expect(result.events.map(e => e.data.studentId)).toEqual(['alice', 'bob']);
+  });
+
+  it('should combine matchType and match', async () => {
+    const result = await store.query<TestEvent>()
+      .matchType('CourseCreated')
+      .matchKey('StudentSubscribed', 'course', 'cs101')
+      .read();
+
+    // Should get: CourseCreated (all) + StudentSubscribed for cs101
+    expect(result.count).toBe(4); // 2 courses + 2 subscriptions for cs101
+  });
+
+  it('should support limit', async () => {
+    const result = await store.query<TestEvent>()
+      .matchType('StudentSubscribed')
+      .limit(2)
+      .read();
+
+    expect(result.count).toBe(2);
+  });
+
+  it('should support fromPosition', async () => {
+    // First, get all events to know positions
+    const all = await store.query<TestEvent>()
+      .matchType('StudentSubscribed')
+      .read();
+
+    expect(all.count).toBe(3);
+
+    // Now read from position of first subscription
+    const fromPos = await store.query<TestEvent>()
+      .matchType('StudentSubscribed')
+      .fromPosition(all.events[0].position)
+      .read();
+
+    // Should get events after the first one
+    expect(fromPos.count).toBe(2);
+  });
+
+  it('should chain multiple conditions', async () => {
+    const result = await store.query<TestEvent>()
+      .matchKey('StudentSubscribed', 'student', 'alice')
+      .read();
+
+    // Alice is subscribed to both courses
+    expect(result.count).toBe(2);
+  });
+
+  it('should return appendCondition for consistency', async () => {
+    const result = await store.query<TestEvent>()
+      .matchKey('StudentSubscribed', 'course', 'cs101')
+      .read();
+
+    expect(result.appendCondition).toBeDefined();
+    expect(result.appendCondition.conditions).toHaveLength(1);
+    expect(result.appendCondition.conditions[0]).toEqual({
+      type: 'StudentSubscribed',
+      key: 'course',
+      value: 'cs101'
+    });
+  });
+
+  it('should work with empty results', async () => {
+    const result = await store.query<TestEvent>()
+      .matchKey('StudentSubscribed', 'course', 'nonexistent')
+      .read();
+
+    expect(result.isEmpty()).toBe(true);
+    expect(result.count).toBe(0);
+  });
+});

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -430,12 +430,13 @@
   <div class="tabs-container">
     <div class="tabs-header">
       <button class="tab-btn active" data-tab="pattern">The Pattern</button>
+      <button class="tab-btn" data-tab="fluent">Fluent API</button>
       <button class="tab-btn" data-tab="impl">Decide / Evolve</button>
     </div>
     
     <div class="tabs-content-wrapper">
       <div class="tab-content active" id="tab-pattern">
-        <div class="tab-label">Read → Reduce → Decide → Write</div>
+        
         <pre><code><span class="comment">// 1. Read with typed events</span>
 <span class="keyword">const</span> { events, appendCondition } = <span class="keyword">await</span> store.<span class="function">read</span>&lt;CourseEvent&gt;({
   conditions: [
@@ -454,8 +455,25 @@
 <span class="keyword">await</span> store.<span class="function">append</span>(newEvents, appendCondition);</code></pre>
       </div>
       
+      <div class="tab-content" id="tab-fluent">
+        
+        <pre><code><span class="keyword">const</span> { events, appendCondition } = <span class="keyword">await</span> store.<span class="function">query</span>&lt;CourseEvent&gt;()
+  .<span class="function">matchType</span>(<span class="string">'CourseCreated'</span>)
+  .<span class="function">matchKey</span>(<span class="string">'StudentSubscribed'</span>, <span class="string">'course'</span>, <span class="string">'cs101'</span>)
+  .<span class="function">read</span>();
+
+<span class="comment">// Build state</span>
+<span class="keyword">const</span> state: CourseState = events.<span class="function">reduce</span>(evolve, initialState);
+
+<span class="comment">// Business logic</span>
+<span class="keyword">const</span> newEvents: CourseEvent[] = <span class="function">decide</span>(command, state);
+
+<span class="comment">// Append</span>
+<span class="keyword">await</span> store.<span class="function">append</span>(newEvents, appendCondition);</code></pre>
+      </div>
+      
       <div class="tab-content" id="tab-impl">
-        <div class="tab-label">Define Your Functions</div>
+        
         <pre><code><span class="keyword">const</span> initialState = { enrolled: <span class="const">0</span>, capacity: <span class="const">30</span> };
 
 <span class="comment">// evolve: (state, event) → new state</span>


### PR DESCRIPTION
## Fluent Query Builder

```typescript
const result = await store.query<CourseEvent>()
  .ofType('CourseCreated')                              // unconstrained
  .match('StudentSubscribed', 'course', 'cs101')        // constrained
  .fromPosition(100n)
  .limit(50)
  .read();
```

### Methods

| Method | Description |
|--------|-------------|
| `ofType(type)` | Unconstrained - match all events of type |
| `match(type, key, value)` | Constrained - match where key equals value |
| `fromPosition(bigint)` | Start from position |
| `limit(number)` | Limit results |
| `read()` | Execute and return QueryResult |

### Tests

8 new tests covering:
- `ofType()` unconstrained queries
- `match()` constrained queries  
- Combined conditions
- `limit()` and `fromPosition()`
- `appendCondition` for consistency
- Empty results