### PR TITLE
ci: add npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,27 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - name: Set version from tag
+        run: npm version "${GITHUB_REF#refs/tags/v}" --no-git-tag-version
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds GitHub Actions workflow for automated npm publishing.

## Workflow
- Triggers on tag push matching `v*`
- Runs build + tests before publishing
- Uses `--provenance` for supply chain security

## Setup Required
Add `NPM_TOKEN` secret to repository settings.

## Usage
```bash
git tag v1.0.1
git push origin v1.0.1
```
→ Automatically publishes to npm 🚀