### PR TITLE
docs: update landing page tabs

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -463,7 +463,10 @@
         <pre><code><span class="keyword">const</span> { events, appendCondition } = <span class="keyword">await</span> store.<span class="function">query</span>&lt;CourseEvent&gt;()
   .<span class="function">matchType</span>(<span class="string">'CourseCreated'</span>)                        <span class="comment">// all CourseCreated</span>
   .<span class="function">matchKey</span>(<span class="string">'StudentSubscribed'</span>, <span class="string">'course'</span>, <span class="string">'cs101'</span>)  <span class="comment">// + where course='cs101'</span>
-  .<span class="function">read</span>();</code></pre>
+  .<span class="function">read</span>();
+
+<span class="comment">// Build state</span>
+<span class="keyword">const</span> state: CourseState = events.<span class="function">reduce</span>(evolve, initialState);</code></pre>
       </div>
       
       <div class="tab-content" id="tab-append">


### PR DESCRIPTION
Updates the tabbed code examples:

**Before:** The Pattern | Fluent API | Decide / Evolve  
**After:** Fluent API | Conflict | Decide / Evolve

- Removes "The Pattern" tab (redundant with Fluent API)
- Adds "Conflict" tab showing conflict handling code
- Fluent API is now the default (first) tab