### PR TITLE
docs: add matchAnyType to landing page

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -463,7 +463,7 @@
         <pre><code><span class="keyword">const</span> { events, appendCondition } = <span class="keyword">await</span> store.<span class="function">query</span>&lt;CourseEvent&gt;()
   .<span class="function">matchType</span>(<span class="string">'CourseCreated'</span>)                              <span class="comment">// all CourseCreated</span>
   .<span class="function">matchTypeAndKey</span>(<span class="string">'StudentSubscribed'</span>, <span class="string">'course'</span>, <span class="string">'cs101'</span>) <span class="comment">// type + key</span>
-  .<span class="function">matchKey</span>(<span class="string">'course'</span>, <span class="string">'cs101'</span>)                            <span class="comment">// ALL events for cs101</span>
+  .<span class="function">matchKey</span>(<span class="string">'student'</span>, <span class="string">'alice'</span>)                           <span class="comment">// ALL events for alice</span>
   .<span class="function">read</span>();
 
 <span class="comment">// Build state</span>


### PR DESCRIPTION
Adds the new `matchAnyType()` method to the Query tab example on the landing page.

Shows all three query methods:
- `matchType()` — all events of type
- `matchKey()` — events where key=value
- `matchAnyType()` — ALL events with key=value (any type)

Related to PR #33 (key-only queries feature).