### PR TITLE
fix: Allow same version in npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - name: Set version from tag
-        run: npm version "${GITHUB_REF#refs/tags/v}" --no-git-tag-version
+        run: npm version "${GITHUB_REF#refs/tags/v}" --no-git-tag-version --allow-same-version
       - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
Adds `--allow-same-version` flag to prevent failure when version is already set in package.json