### PR TITLE
fix: handle BigInt serialization in demo UI

### DIFF
--- a/ui/public/demo.html
+++ b/ui/public/demo.html
@@ -632,7 +632,7 @@
     function addDebugLine(debugLog, prefix, color, args) {
       const line = document.createElement('div');
       line.style.color = color;
-      line.textContent = prefix + ' ' + Array.from(args).map(a => typeof a === 'object' ? JSON.stringify(a) : String(a)).join(' ');
+      line.textContent = prefix + ' ' + Array.from(args).map(a => typeof a === 'object' ? JSON.stringify(a, (k, v) => typeof v === 'bigint' ? v.toString() : v) : String(a)).join(' ');
       debugLog.appendChild(line);
       debugLog.scrollTop = debugLog.scrollHeight;
       // Keep only last 100 lines
@@ -1415,7 +1415,7 @@
       const el = document.getElementById(id);
       if (!el) return;
       el.style.display = 'block';
-      el.textContent = JSON.stringify(data, null, 2);
+      el.textContent = JSON.stringify(data, (k, v) => typeof v === 'bigint' ? v.toString() : v, 2);
     }
 
     // Quick Actions - directly append


### PR DESCRIPTION
Fixes the 'Do not know how to serialize a Bigint' error in the demo UI.

**Changes:**
- Debug log now uses a BigInt-safe replacer in `JSON.stringify`
- `showJsonResult` function also handles BigInt properly

**Problem:**
When AppendCondition contains `after` (a bigint), logging or displaying it via `JSON.stringify()` threw an error because JavaScript's native `JSON.stringify` doesn't support BigInt.