### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to BoundlessDB will be documented in this file.
 
-## [0.3.0] - Unreleased
+## [0.3.0] - 2026-02-23
 
 ### Breaking Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boundlessdb",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boundlessdb",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boundlessdb",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "description": "A DCB-inspired event store library for TypeScript — with support for SQLite, PostgreSQL, in-memory",
   "author": "Sebastian Bortz",


### PR DESCRIPTION
Version bump for v0.3.0 release.

**Breaking Change:** Removed key-only queries (see CHANGELOG.md)