### PR TITLE
feat: add favicon

### DIFF
--- a/ui/public/demo.html
+++ b/ui/public/demo.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>BoundlessDB DCB Event Store - Interactive Demo</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {

--- a/ui/public/favicon.svg
+++ b/ui/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="4" y="4" width="24" height="24" rx="3" fill="#1a1a2e" stroke="#0cc" stroke-width="2"/>
+  <rect x="8" y="8" width="16" height="5" rx="1" fill="#0cc"/>
+  <rect x="8" y="15" width="16" height="5" rx="1" fill="#0cc" opacity="0.7"/>
+  <rect x="8" y="22" width="16" height="5" rx="1" fill="#0cc" opacity="0.4"/>
+</svg>

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>BoundlessDB — DCB Event Store</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <style>
     :root {
       --content-width: 900px;


### PR DESCRIPTION
Adds an SVG favicon matching the 🗃️ logo style.

- Stacked rectangles representing event layers
- Cyan (#0cc) on dark background
- Works on both landing page and demo