### PR TITLE
feat: split append benchmark into recent-read vs cold-read

### DIFF
--- a/benchmark/postgres-query.ts
+++ b/benchmark/postgres-query.ts
@@ -120,6 +120,18 @@ async function generateEvents(
     }
   }
 
+  // Add a "latest" course at the very end for the recent-read benchmark
+  await store.append([
+    { type: 'CourseCreated', data: { courseId: 'course-latest', title: 'Latest Course' } },
+  ], null);
+  totalEvents++;
+  for (let s = 0; s < 5; s++) {
+    await store.append([
+      { type: 'StudentEnrolled', data: { courseId: 'course-latest', studentId: `student-latest-${s}` } },
+    ], null);
+    totalEvents++;
+  }
+
   const elapsed = performance.now() - genStart;
   const evtPerSec = totalEvents / (elapsed / 1000);
   process.stdout.write(
@@ -190,7 +202,7 @@ const queries: QueryDef[] = [
       .read(),
   },
   {
-    name: 'Append (single event)',
+    name: 'Append (no condition)',
     fn: (store) => {
       let counter = 0;
       return async () => {
@@ -202,15 +214,30 @@ const queries: QueryDef[] = [
     },
   },
   {
-    name: 'Append with condition',
+    name: 'Append (recent read)',
     fn: (store) => {
       let counter = 0;
       return async () => {
         const read = await store.query()
-          .matchTypeAndKey('StudentEnrolled', 'course', 'course-50')
+          .matchTypeAndKey('StudentEnrolled', 'course', 'course-latest')
           .read();
         await store.append([
-          { type: 'LessonCompleted', data: { courseId: 'course-bench2', studentId: 'student-bench2', lessonId: `lesson-${counter++}` } },
+          { type: 'LessonCompleted', data: { courseId: 'course-latest', studentId: 'student-bench', lessonId: `lesson-${counter++}` } },
+        ], read.appendCondition);
+        return { count: 1 };
+      };
+    },
+  },
+  {
+    name: 'Append (cold read)',
+    fn: (store) => {
+      let counter = 0;
+      return async () => {
+        const read = await store.query()
+          .matchTypeAndKey('StudentEnrolled', 'course', 'course-0')
+          .read();
+        await store.append([
+          { type: 'LessonCompleted', data: { courseId: 'course-cold', studentId: 'student-bench', lessonId: `lesson-${counter++}` } },
         ], read.appendCondition);
         return { count: 1 };
       };

--- a/benchmark/sqlite-query.ts
+++ b/benchmark/sqlite-query.ts
@@ -120,6 +120,18 @@ async function generateEvents(
     }
   }
 
+  // Add a "latest" course at the very end for the recent-read benchmark
+  await store.append([
+    { type: 'CourseCreated', data: { courseId: 'course-latest', title: 'Latest Course' } },
+  ], null);
+  totalEvents++;
+  for (let s = 0; s < 5; s++) {
+    await store.append([
+      { type: 'StudentEnrolled', data: { courseId: 'course-latest', studentId: `student-latest-${s}` } },
+    ], null);
+    totalEvents++;
+  }
+
   const elapsed = performance.now() - genStart;
   const evtPerSec = totalEvents / (elapsed / 1000);
   process.stdout.write(
@@ -190,7 +202,7 @@ const queries: QueryDef[] = [
       .read(),
   },
   {
-    name: 'Append (single event)',
+    name: 'Append (no condition)',
     fn: (store) => {
       let counter = 0;
       return async () => {
@@ -202,15 +214,32 @@ const queries: QueryDef[] = [
     },
   },
   {
-    name: 'Append with condition',
+    name: 'Append (recent read)',
     fn: (store) => {
       let counter = 0;
       return async () => {
+        // Read the latest course (near end of store) - realistic use case
         const read = await store.query()
-          .matchTypeAndKey('StudentEnrolled', 'course', 'course-50')
+          .matchTypeAndKey('StudentEnrolled', 'course', 'course-latest')
           .read();
         await store.append([
-          { type: 'LessonCompleted', data: { courseId: 'course-bench2', studentId: 'student-bench2', lessonId: `lesson-${counter++}` } },
+          { type: 'LessonCompleted', data: { courseId: 'course-latest', studentId: 'student-bench', lessonId: `lesson-${counter++}` } },
+        ], read.appendCondition);
+        return { count: 1 };
+      };
+    },
+  },
+  {
+    name: 'Append (cold read)',
+    fn: (store) => {
+      let counter = 0;
+      return async () => {
+        // Read an early course (position near 0) - worst case
+        const read = await store.query()
+          .matchTypeAndKey('StudentEnrolled', 'course', 'course-0')
+          .read();
+        await store.append([
+          { type: 'LessonCompleted', data: { courseId: 'course-cold', studentId: 'student-bench', lessonId: `lesson-${counter++}` } },
         ], read.appendCondition);
         return { count: 1 };
       };


### PR DESCRIPTION
**Vorher:** Ein einzelner "Append with condition" Benchmark der immer course-50 liest (Position nahe Anfang = Worst Case).

**Nachher:** Drei Append-Benchmarks:

| Benchmark | Was passiert | Misst |
|---|---|---|
| Append (no condition) | Blind append, kein Read | Baseline Write-Latenz |
| Append (recent read) | Liest course-latest (Position nahe Ende) | Realistischer Use Case |
| Append (cold read) | Liest course-0 (Position nahe 0) | Worst Case |

Der Unterschied zwischen recent-read und cold-read zeigt direkt den Einfluss der Read-Distance auf die Condition-Check Performance.

`course-latest` wird am Ende der Datengenerierung mit 5 Enrollments angelegt, damit die Position nah am Tail liegt.

Zweigt von main ab, unabhängig mergbar.