### PR TITLE
docs: Changelog, README multi-node section, landing page update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to BoundlessDB will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Atomic conflict detection**: `appendWithCondition()` performs conflict check and write in a single transaction. Enables safe multi-node deployments (e.g. Supabase Edge Functions).
+- **PostgreSQL SERIALIZABLE isolation**: Concurrent appends with overlapping consistency keys are detected automatically. Auto-retry on serialization failure (max 3 attempts).
+- **PostgreSQL 50M benchmark results** on landing page.
+
+### Changed
+
+- **Storage interface**: `append()` + `getEventsSince()` replaced by `appendWithCondition()`. Public API (`store.read()`, `store.append()`, `store.query()`) is unchanged.
+- Conflict check logic moved from EventStore into Storage layer for atomicity.
+
+### Performance
+
+- **50M events (PostgreSQL 16, shuffled):**
+  - Constrained (167 results): 3.73ms
+  - Highly selective (10 results): 1.14ms
+  - Mixed 2 types (334 results): 3.83ms
+  - Full aggregate (2,004 results): 7.96ms
+  - Write throughput: 3,797 evt/s (LUKS encrypted)
+
 ## [0.3.1] - 2026-02-24
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -367,6 +367,30 @@ npm run build:browser
 # → ui/public/boundless.browser.js (~100KB)
 ```
 
+## Multi-Node Safety
+
+BoundlessDB supports concurrent access from multiple processes (e.g. Supabase Edge Functions, multiple server instances) when using PostgreSQL.
+
+The conflict check and write happen **atomically in a single SERIALIZABLE transaction**. PostgreSQL detects overlapping reads and aborts one transaction if two processes try to append with conflicting consistency keys. The library retries automatically.
+
+```typescript
+// Edge Function A and B run simultaneously:
+// Both read, both decide, both try to append.
+// PostgreSQL ensures only one succeeds — the other gets a conflict result.
+
+const result = await store.append(newEvents, appendCondition);
+if (result.conflict) {
+  // Retry with fresh state
+}
+```
+
+**Key behavior:**
+- Appends with **different keys** proceed in parallel (no conflict)
+- Appends with **overlapping keys** are serialized (one wins, one retries)
+- This maps directly to DCB's Dynamic Consistency Boundaries
+
+**No configuration needed** — atomic conflict detection is built into all storage engines.
+
 ## Storage Backends
 
 | Backend | Environment | Persistence |

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -560,6 +560,11 @@
       <p>SQLite for embedded, PostgreSQL for production, sql.js for browser, or in-memory for testing.</p>
     </div>
     <div class="feature">
+      <div class="feature-icon">🔒</div>
+      <h3>Multi-Node Safe</h3>
+      <p>Atomic conflict detection via SERIALIZABLE transactions. Safe for Supabase Edge Functions and concurrent deployments.</p>
+    </div>
+    <div class="feature">
       <div class="feature-icon">📦</div>
       <h3>Embedded Library</h3>
       <p>Runs in your process — no separate server needed. (No gRPC/HTTP API yet.)</p>


### PR DESCRIPTION
## Changes

### CHANGELOG.md
- `[Unreleased]` section with atomic `appendWithCondition` feature
- PostgreSQL 50M benchmark results

### README.md
- New **Multi-Node Safety** section explaining:
  - SERIALIZABLE transactions for concurrent access
  - Automatic retry on serialization failure
  - How DCB maps to PostgreSQL concurrency (different keys = parallel, overlapping keys = serialized)
  - No configuration needed

### Landing Page
- New feature card: "🔒 Multi-Node Safe"
- PostgreSQL 50M benchmark numbers filled in
- Simplified footnotes

Tests: 118 passing ✅