### PR TITLE
fix: update repository URL to boundlessdb

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Sebastian Bortz",
   "repository": {
     "type": "git",
-    "url": "https://github.com/SBortz/boundless.git"
+    "url": "https://github.com/SBortz/boundlessdb.git"
   },
   "homepage": "https://boundlessdb.dev",
   "keywords": [


### PR DESCRIPTION
npm publish with provenance fails because `package.json` still references the old repo name (`SBortz/boundless` instead of `SBortz/boundlessdb`).

After merge: delete tag v0.4.0, re-tag, push → npm publish should work.