### PR TITLE
feat: Projection system with EventNotifier adapters (#58)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,3 +43,10 @@ export { validateConfig, ConfigValidationError } from './config/validator.js';
 
 // Query Builder
 export { QueryBuilder } from './query-builder.js';
+
+// Projections
+export type { EventNotifier } from './projections/notifier.js';
+export type { ProjectionHandler, ProjectionState } from './projections/types.js';
+export { InProcessNotifier } from './projections/in-process-notifier.js';
+export { PollingNotifier, type PollingNotifierOptions } from './projections/polling-notifier.js';
+export { ProjectionRunner } from './projections/runner.js';

--- a/src/projections/in-process-notifier.ts
+++ b/src/projections/in-process-notifier.ts
@@ -1,0 +1,40 @@
+/**
+ * InProcessNotifier
+ * 
+ * Simple in-process event emitter for notifying about new events.
+ * Used with SQLite, sql.js, and InMemory storage engines.
+ */
+
+import type { EventNotifier } from './notifier.js';
+
+export class InProcessNotifier implements EventNotifier {
+  private callbacks: ((pos: bigint) => void)[] = [];
+
+  /**
+   * Register callback for new events
+   */
+  onNewEvents(callback: (pos: bigint) => void): void {
+    this.callbacks.push(callback);
+  }
+
+  /**
+   * Notify all registered callbacks about new events
+   * @param position Position of the latest appended event
+   */
+  notify(position: bigint): void {
+    for (const cb of this.callbacks) {
+      try {
+        cb(position);
+      } catch (error) {
+        console.error('[InProcessNotifier] Error in callback:', error);
+      }
+    }
+  }
+
+  /**
+   * Stop listening and clear all callbacks
+   */
+  close(): void {
+    this.callbacks = [];
+  }
+}

--- a/src/projections/notifier.ts
+++ b/src/projections/notifier.ts
@@ -1,0 +1,18 @@
+/**
+ * EventNotifier Interface
+ * 
+ * Abstracts notification mechanism for new events in the event store.
+ */
+
+export interface EventNotifier {
+  /**
+   * Register callback for new events
+   * @param callback Called with the position of the latest event
+   */
+  onNewEvents(callback: (fromPosition: bigint) => void): void;
+
+  /**
+   * Stop listening for events
+   */
+  close(): void;
+}

--- a/src/projections/polling-notifier.ts
+++ b/src/projections/polling-notifier.ts
@@ -1,0 +1,97 @@
+/**
+ * PollingNotifier
+ * 
+ * Universal fallback notifier that polls the event store for new events.
+ * Works with any storage engine.
+ */
+
+import type { EventStorage } from '../storage/interface.js';
+import type { EventNotifier } from './notifier.js';
+
+export interface PollingNotifierOptions {
+  /** Polling interval in milliseconds (default: 1000) */
+  intervalMs?: number;
+}
+
+export class PollingNotifier implements EventNotifier {
+  private callbacks: ((pos: bigint) => void)[] = [];
+  private intervalHandle?: ReturnType<typeof setInterval>;
+  private lastKnownPosition: bigint = 0n;
+  private readonly intervalMs: number;
+
+  constructor(
+    private readonly storage: EventStorage,
+    options: PollingNotifierOptions = {}
+  ) {
+    this.intervalMs = options.intervalMs ?? 1000;
+  }
+
+  /**
+   * Register callback for new events
+   */
+  onNewEvents(callback: (pos: bigint) => void): void {
+    const isFirstCallback = this.callbacks.length === 0;
+    this.callbacks.push(callback);
+
+    // Start polling when first callback is registered
+    if (isFirstCallback) {
+      this.startPolling();
+    }
+  }
+
+  /**
+   * Start polling for new events
+   */
+  private startPolling(): void {
+    if (this.intervalHandle) {
+      return; // Already polling
+    }
+
+    // Initialize last known position
+    this.storage.getLatestPosition().then(pos => {
+      this.lastKnownPosition = pos;
+    }).catch(err => {
+      console.error('[PollingNotifier] Error getting initial position:', err);
+    });
+
+    this.intervalHandle = setInterval(() => {
+      this.poll();
+    }, this.intervalMs);
+  }
+
+  /**
+   * Poll for new events
+   */
+  private async poll(): Promise<void> {
+    try {
+      const currentPosition = await this.storage.getLatestPosition();
+      
+      if (currentPosition > this.lastKnownPosition) {
+        this.lastKnownPosition = currentPosition;
+        
+        // Notify all callbacks
+        for (const cb of this.callbacks) {
+          try {
+            cb(currentPosition);
+          } catch (error) {
+            console.error('[PollingNotifier] Error in callback:', error);
+          }
+        }
+      }
+    } catch (error) {
+      console.error('[PollingNotifier] Error polling for events:', error);
+    }
+  }
+
+  /**
+   * Stop polling and clear all callbacks
+   */
+  close(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = undefined;
+    }
+    this.callbacks = [];
+    this.lastKnownPosition = 0n;
+  }
+}

--- a/src/projections/runner.ts
+++ b/src/projections/runner.ts
@@ -1,0 +1,160 @@
+/**
+ * ProjectionRunner
+ * 
+ * Manages running projections with catchup and live updates.
+ */
+
+import type { EventStore } from '../event-store.js';
+import type { EventNotifier } from './notifier.js';
+import type { ProjectionHandler, ProjectionState } from './types.js';
+
+export class ProjectionRunner {
+  private states: Map<string, ProjectionState> = new Map();
+  private running = false;
+
+  constructor(
+    private readonly store: EventStore,
+    private readonly notifier: EventNotifier,
+    private readonly projections: Record<string, ProjectionHandler>
+  ) {}
+
+  /**
+   * Start the projection runner
+   * - Performs catchup (reads all events since last position)
+   * - Starts listening for new events
+   */
+  async start(): Promise<void> {
+    if (this.running) {
+      throw new Error('ProjectionRunner is already running');
+    }
+
+    this.running = true;
+
+    // Initialize states
+    for (const [name, handler] of Object.entries(this.projections)) {
+      this.states.set(name, {
+        state: handler.init,
+        lastPosition: 0n,
+      });
+    }
+
+    // Perform catchup for each projection
+    await this.catchup();
+
+    // Start listening for new events
+    this.notifier.onNewEvents((position) => {
+      this.processNewEvents(position).catch(err => {
+        console.error('[ProjectionRunner] Error processing new events:', err);
+      });
+    });
+  }
+
+  /**
+   * Catchup: read all events since last position and rebuild state
+   */
+  private async catchup(): Promise<void> {
+    for (const [name, handler] of Object.entries(this.projections)) {
+      const projectionState = this.states.get(name)!;
+      
+      // Build query conditions from handler
+      const conditions = handler.query ?? Object.keys(handler.when).map(type => ({ type }));
+      
+      if (conditions.length === 0) {
+        continue; // No events to process
+      }
+
+      // Read all events since last position
+      const result = await this.store.read({
+        conditions,
+        fromPosition: projectionState.lastPosition,
+      });
+
+      // Process events
+      let currentState = projectionState.state;
+      for (const event of result.events) {
+        const eventHandler = handler.when[event.type];
+        if (eventHandler) {
+          currentState = eventHandler(currentState, event);
+          projectionState.lastPosition = event.position;
+        }
+      }
+
+      // Update state
+      projectionState.state = currentState;
+    }
+  }
+
+  /**
+   * Process new events (called by notifier)
+   */
+  private async processNewEvents(latestPosition: bigint): Promise<void> {
+    if (!this.running) {
+      return;
+    }
+
+    for (const [name, handler] of Object.entries(this.projections)) {
+      const projectionState = this.states.get(name)!;
+      
+      // Skip if we've already processed up to this position
+      if (projectionState.lastPosition >= latestPosition) {
+        continue;
+      }
+
+      // Build query conditions
+      const conditions = handler.query ?? Object.keys(handler.when).map(type => ({ type }));
+      
+      if (conditions.length === 0) {
+        continue;
+      }
+
+      // Read events since last position
+      const result = await this.store.read({
+        conditions,
+        fromPosition: projectionState.lastPosition,
+      });
+
+      // Process events
+      let currentState = projectionState.state;
+      for (const event of result.events) {
+        const eventHandler = handler.when[event.type];
+        if (eventHandler) {
+          currentState = eventHandler(currentState, event);
+          projectionState.lastPosition = event.position;
+        }
+      }
+
+      // Update state
+      projectionState.state = currentState;
+    }
+  }
+
+  /**
+   * Stop the projection runner
+   */
+  stop(): void {
+    if (!this.running) {
+      return;
+    }
+
+    this.running = false;
+    this.notifier.close();
+  }
+
+  /**
+   * Get current state of a projection
+   */
+  getState<T = unknown>(name: string): ProjectionState<T> {
+    const state = this.states.get(name);
+    if (!state) {
+      throw new Error(`Projection '${name}' not found`);
+    }
+    return state as ProjectionState<T>;
+  }
+
+  /**
+   * Check if runner is currently running
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+}

--- a/src/projections/types.ts
+++ b/src/projections/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Projection Types
+ * 
+ * Types for defining and managing projections.
+ */
+
+import type { StoredEvent, QueryCondition } from '../types.js';
+
+/**
+ * ProjectionHandler defines how a projection processes events
+ */
+export interface ProjectionHandler<TState = unknown> {
+  /**
+   * Initial state of the projection
+   */
+  init: TState;
+
+  /**
+   * Event handlers: map event type to state reducer
+   */
+  when: Record<string, (state: TState, event: StoredEvent) => TState>;
+
+  /**
+   * Optional query conditions to filter which events this projection cares about
+   * If omitted, all events matching the `when` handlers will be processed
+   */
+  query?: QueryCondition[];
+}
+
+/**
+ * Current state of a running projection
+ */
+export interface ProjectionState<TState = unknown> {
+  /**
+   * Current projection state
+   */
+  state: TState;
+
+  /**
+   * Last processed event position
+   */
+  lastPosition: bigint;
+}

--- a/test/projections.test.ts
+++ b/test/projections.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Tests for Projection System
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  EventStore,
+  InMemoryStorage,
+  InProcessNotifier,
+  ProjectionRunner,
+  type ConsistencyConfig,
+  type ProjectionHandler,
+} from '../src/index.js';
+
+const TEST_CONFIG: ConsistencyConfig = {
+  eventTypes: {
+    CourseCreated: {
+      keys: [{ name: 'course', path: 'data.courseId' }],
+    },
+    StudentSubscribed: {
+      keys: [
+        { name: 'course', path: 'data.courseId' },
+        { name: 'student', path: 'data.studentId' },
+      ],
+    },
+    StudentUnsubscribed: {
+      keys: [
+        { name: 'course', path: 'data.courseId' },
+        { name: 'student', path: 'data.studentId' },
+      ],
+    },
+  },
+};
+
+type CourseState = {
+  courses: Record<string, { name: string; studentCount: number }>;
+};
+
+type StudentState = {
+  subscriptions: string[];
+};
+
+describe('Projection System', () => {
+  let store: EventStore;
+  let notifier: InProcessNotifier;
+  let runner: ProjectionRunner;
+
+  beforeEach(() => {
+    const storage = new InMemoryStorage();
+    notifier = new InProcessNotifier();
+    store = new EventStore({
+      storage,
+      consistency: TEST_CONFIG,
+    });
+  });
+
+  afterEach(() => {
+    if (runner?.isRunning()) {
+      runner.stop();
+    }
+  });
+
+  describe('InProcessNotifier', () => {
+    it('notifies callbacks when notify() is called', async () => {
+      const positions: bigint[] = [];
+      
+      notifier.onNewEvents((pos) => {
+        positions.push(pos);
+      });
+
+      notifier.notify(1n);
+      notifier.notify(2n);
+      notifier.notify(3n);
+
+      expect(positions).toEqual([1n, 2n, 3n]);
+    });
+
+    it('supports multiple callbacks', async () => {
+      const positions1: bigint[] = [];
+      const positions2: bigint[] = [];
+      
+      notifier.onNewEvents((pos) => positions1.push(pos));
+      notifier.onNewEvents((pos) => positions2.push(pos));
+
+      notifier.notify(42n);
+
+      expect(positions1).toEqual([42n]);
+      expect(positions2).toEqual([42n]);
+    });
+
+    it('clears callbacks on close', async () => {
+      const positions: bigint[] = [];
+      
+      notifier.onNewEvents((pos) => positions.push(pos));
+      notifier.notify(1n);
+      
+      notifier.close();
+      notifier.notify(2n);
+
+      expect(positions).toEqual([1n]);
+    });
+
+    it('handles callback errors gracefully', async () => {
+      const positions: bigint[] = [];
+      
+      notifier.onNewEvents(() => {
+        throw new Error('Test error');
+      });
+      notifier.onNewEvents((pos) => positions.push(pos));
+
+      notifier.notify(1n);
+
+      // Second callback should still be called
+      expect(positions).toEqual([1n]);
+    });
+  });
+
+  describe('ProjectionRunner - Catchup', () => {
+    it('builds state from existing events', async () => {
+      // Append events before starting projection
+      await store.append(
+        [
+          { type: 'CourseCreated', data: { courseId: 'cs101', name: 'Intro to CS' } },
+          { type: 'CourseCreated', data: { courseId: 'cs102', name: 'Advanced CS' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'bob' } },
+        ],
+        null
+      );
+
+      // Define projection
+      const courseProjection: ProjectionHandler<CourseState> = {
+        init: { courses: {} },
+        when: {
+          CourseCreated: (state, event) => {
+            const { courseId, name } = event.data as { courseId: string; name: string };
+            return {
+              courses: {
+                ...state.courses,
+                [courseId]: { name, studentCount: 0 },
+              },
+            };
+          },
+          StudentSubscribed: (state, event) => {
+            const { courseId } = event.data as { courseId: string; studentId: string };
+            const course = state.courses[courseId];
+            if (!course) return state;
+            return {
+              courses: {
+                ...state.courses,
+                [courseId]: { ...course, studentCount: course.studentCount + 1 },
+              },
+            };
+          },
+        },
+      };
+
+      // Start projection
+      runner = new ProjectionRunner(store, notifier, {
+        courseStats: courseProjection,
+      });
+      await runner.start();
+
+      // Check state
+      const state = runner.getState<CourseState>('courseStats');
+      expect(state.state.courses).toEqual({
+        cs101: { name: 'Intro to CS', studentCount: 2 },
+        cs102: { name: 'Advanced CS', studentCount: 0 },
+      });
+      expect(state.lastPosition).toBe(4n);
+    });
+
+    it('processes only events matching query conditions', async () => {
+      await store.append(
+        [
+          { type: 'CourseCreated', data: { courseId: 'cs101', name: 'Intro to CS' } },
+          { type: 'CourseCreated', data: { courseId: 'cs102', name: 'Advanced CS' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+        ],
+        null
+      );
+
+      // Projection that only cares about CourseCreated
+      const projection: ProjectionHandler<{ count: number }> = {
+        init: { count: 0 },
+        when: {
+          CourseCreated: (state) => ({ count: state.count + 1 }),
+        },
+        query: [{ type: 'CourseCreated' }],
+      };
+
+      runner = new ProjectionRunner(store, notifier, { courseCount: projection });
+      await runner.start();
+
+      const state = runner.getState<{ count: number }>('courseCount');
+      expect(state.state.count).toBe(2);
+      expect(state.lastPosition).toBe(2n);
+    });
+  });
+
+  describe('ProjectionRunner - Live Updates', () => {
+    it('updates state when new events are appended', async () => {
+      const projection: ProjectionHandler<{ count: number }> = {
+        init: { count: 0 },
+        when: {
+          CourseCreated: (state) => ({ count: state.count + 1 }),
+        },
+      };
+
+      runner = new ProjectionRunner(store, notifier, { courseCount: projection });
+      await runner.start();
+
+      // Initial state
+      let state = runner.getState<{ count: number }>('courseCount');
+      expect(state.state.count).toBe(0);
+
+      // Append events and notify
+      const result = await store.append(
+        [
+          { type: 'CourseCreated', data: { courseId: 'cs101', name: 'Intro to CS' } },
+          { type: 'CourseCreated', data: { courseId: 'cs102', name: 'Advanced CS' } },
+        ],
+        null
+      );
+      notifier.notify(result.position);
+
+      // Wait for projection to update
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Check updated state
+      state = runner.getState<{ count: number }>('courseCount');
+      expect(state.state.count).toBe(2);
+      expect(state.lastPosition).toBe(2n);
+    });
+
+    it('handles multiple live updates', async () => {
+      const projection: ProjectionHandler<{ total: number }> = {
+        init: { total: 0 },
+        when: {
+          StudentSubscribed: (state) => ({ total: state.total + 1 }),
+        },
+      };
+
+      runner = new ProjectionRunner(store, notifier, { subscriptionCount: projection });
+      await runner.start();
+
+      // First batch
+      let result = await store.append(
+        [
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+        ],
+        null
+      );
+      notifier.notify(result.position);
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      let state = runner.getState<{ total: number }>('subscriptionCount');
+      expect(state.state.total).toBe(1);
+
+      // Second batch
+      result = await store.append(
+        [
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'bob' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs102', studentId: 'charlie' } },
+        ],
+        result.appendCondition
+      );
+      notifier.notify(result.position);
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      state = runner.getState<{ total: number }>('subscriptionCount');
+      expect(state.state.total).toBe(3);
+    });
+  });
+
+  describe('ProjectionRunner - Multiple Projections', () => {
+    it('runs multiple projections simultaneously', async () => {
+      await store.append(
+        [
+          { type: 'CourseCreated', data: { courseId: 'cs101', name: 'Intro to CS' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'bob' } },
+        ],
+        null
+      );
+
+      const courseProjection: ProjectionHandler<{ count: number }> = {
+        init: { count: 0 },
+        when: {
+          CourseCreated: (state) => ({ count: state.count + 1 }),
+        },
+      };
+
+      const studentProjection: ProjectionHandler<{ count: number }> = {
+        init: { count: 0 },
+        when: {
+          StudentSubscribed: (state) => ({ count: state.count + 1 }),
+        },
+      };
+
+      runner = new ProjectionRunner(store, notifier, {
+        courses: courseProjection,
+        students: studentProjection,
+      });
+      await runner.start();
+
+      expect(runner.getState<{ count: number }>('courses').state.count).toBe(1);
+      expect(runner.getState<{ count: number }>('students').state.count).toBe(2);
+    });
+
+    it('updates multiple projections on new events', async () => {
+      const courseProjection: ProjectionHandler<{ count: number }> = {
+        init: { count: 0 },
+        when: {
+          CourseCreated: (state) => ({ count: state.count + 1 }),
+        },
+      };
+
+      const studentProjection: ProjectionHandler<{ count: number }> = {
+        init: { count: 0 },
+        when: {
+          StudentSubscribed: (state) => ({ count: state.count + 1 }),
+        },
+      };
+
+      runner = new ProjectionRunner(store, notifier, {
+        courses: courseProjection,
+        students: studentProjection,
+      });
+      await runner.start();
+
+      const result = await store.append(
+        [
+          { type: 'CourseCreated', data: { courseId: 'cs101', name: 'Intro to CS' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+        ],
+        null
+      );
+      notifier.notify(result.position);
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(runner.getState<{ count: number }>('courses').state.count).toBe(1);
+      expect(runner.getState<{ count: number }>('students').state.count).toBe(1);
+    });
+  });
+
+  describe('ProjectionRunner - Stop/Start', () => {
+    it('can be stopped and restarted', async () => {
+      const projection: ProjectionHandler<{ count: number }> = {
+        init: { count: 0 },
+        when: {
+          CourseCreated: (state) => ({ count: state.count + 1 }),
+        },
+      };
+
+      runner = new ProjectionRunner(store, notifier, { courseCount: projection });
+      await runner.start();
+      expect(runner.isRunning()).toBe(true);
+
+      runner.stop();
+      expect(runner.isRunning()).toBe(false);
+
+      // Events appended while stopped should not be processed
+      const result = await store.append(
+        [{ type: 'CourseCreated', data: { courseId: 'cs101', name: 'Intro' } }],
+        null
+      );
+      notifier.notify(result.position);
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const state = runner.getState<{ count: number }>('courseCount');
+      expect(state.state.count).toBe(0);
+    });
+
+    it('catches up on restart', async () => {
+      const projection: ProjectionHandler<{ count: number }> = {
+        init: { count: 0 },
+        when: {
+          CourseCreated: (state) => ({ count: state.count + 1 }),
+        },
+      };
+
+      runner = new ProjectionRunner(store, notifier, { courseCount: projection });
+      await runner.start();
+      runner.stop();
+
+      // Append events while stopped
+      await store.append(
+        [
+          { type: 'CourseCreated', data: { courseId: 'cs101', name: 'Course 1' } },
+          { type: 'CourseCreated', data: { courseId: 'cs102', name: 'Course 2' } },
+        ],
+        null
+      );
+
+      // Restart
+      await runner.start();
+
+      const state = runner.getState<{ count: number }>('courseCount');
+      expect(state.state.count).toBe(2);
+    });
+
+    it('throws error if started twice', async () => {
+      const projection: ProjectionHandler<{ count: number }> = {
+        init: { count: 0 },
+        when: {
+          CourseCreated: (state) => ({ count: state.count + 1 }),
+        },
+      };
+
+      runner = new ProjectionRunner(store, notifier, { test: projection });
+      await runner.start();
+
+      await expect(runner.start()).rejects.toThrow('already running');
+    });
+
+    it('does not throw error if stopped twice', () => {
+      const projection: ProjectionHandler<{ count: number }> = {
+        init: { count: 0 },
+        when: {
+          CourseCreated: (state) => ({ count: state.count + 1 }),
+        },
+      };
+
+      runner = new ProjectionRunner(store, notifier, { test: projection });
+      runner.stop();
+      runner.stop(); // Should not throw
+    });
+  });
+
+  describe('ProjectionRunner - Error Cases', () => {
+    it('throws error when getting unknown projection', async () => {
+      const projection: ProjectionHandler<{ count: number }> = {
+        init: { count: 0 },
+        when: {},
+      };
+
+      runner = new ProjectionRunner(store, notifier, { test: projection });
+      await runner.start();
+
+      expect(() => runner.getState('unknown')).toThrow("Projection 'unknown' not found");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a projection system with pluggable notification adapters. Projections catch up on existing events at start, then process new events live via notifiers.

Fixes #58

## New files

- `src/projections/notifier.ts` — `EventNotifier` interface
- `src/projections/in-process-notifier.ts` — Direct callback notifier (SQLite, sql.js, In-Memory)
- `src/projections/polling-notifier.ts` — Universal fallback, polls `getLatestPosition()`
- `src/projections/runner.ts` — `ProjectionRunner` with catchup + live updates
- `src/projections/types.ts` — `ProjectionHandler`, `ProjectionState`
- `test/projections.test.ts` — 15 tests

## Usage

```typescript
import { ProjectionRunner, InProcessNotifier } from "boundlessdb";

const notifier = new InProcessNotifier();

const runner = new ProjectionRunner(store, notifier, {
  courseStats: {
    init: { enrolled: 0 },
    when: {
      StudentSubscribed: (state, event) => ({ enrolled: state.enrolled + 1 }),
      StudentUnsubscribed: (state, event) => ({ enrolled: state.enrolled - 1 }),
    },
    query: [{ type: "StudentSubscribed" }, { type: "StudentUnsubscribed" }],
  },
});

await runner.start();

// After appending events, notify:
notifier.notify(position);

// Read state:
const { state, lastPosition } = runner.getState("courseStats");
```

## Design decisions

- **In-memory bookmarks only** (persistent bookmarks = future PR)
- **Not exported from browser bundle** (requires Node.js timers)
- **No changes to existing storage engines** (InProcessNotifier is standalone)

## Tests

133 passing (+15 new), 27 skipped (PostgreSQL)

## Future PRs
- PostgreSQL `LISTEN/NOTIFY` adapter
- Supabase Realtime adapter
- Persistent bookmark storage
- Catchup-only mode (batch processing without live updates)