### PR TITLE
feat: add store.all() method to read all events without type filters

### DIFF
--- a/src/event-store.browser.ts
+++ b/src/event-store.browser.ts
@@ -25,6 +25,7 @@ import {
   type QueryCondition,
   type StoredEvent,
 } from './types.js';
+import { QueryBuilder, type QueryExecutor } from './query-builder.js';
 
 /**
  * Generate UUID with fallback for environments without crypto.randomUUID
@@ -170,6 +171,32 @@ export class EventStore {
       console.warn('⚠️ INIT: Config hash check failed (non-fatal):', error);
       // Don't throw for other errors - config hash is nice-to-have, not required
     }
+  }
+
+  /**
+   * Create a fluent query builder.
+   * 
+   * @typeParam E - Event union type for typed results
+   * @returns QueryBuilder for chaining
+   */
+  query<E extends Event = Event>(): QueryBuilder<E> {
+    return new QueryBuilder<E>(this as unknown as QueryExecutor<E>);
+  }
+
+  /**
+   * Create a fluent query builder that reads all events (no type filter required).
+   * 
+   * @typeParam E - Event union type for typed results
+   * @returns QueryBuilder for chaining
+   * 
+   * @example
+   * ```typescript
+   * const result = await store.all().fromPosition(0n).limit(1000).read();
+   * const result = await store.all().read();
+   * ```
+   */
+  all<E extends Event = Event>(): QueryBuilder<E> {
+    return new QueryBuilder<E>(this as unknown as QueryExecutor<E>);
   }
 
   /**

--- a/src/event-store.ts
+++ b/src/event-store.ts
@@ -125,6 +125,29 @@ export class EventStore {
   }
 
   /**
+   * Create a fluent query builder that reads all events (no type filter required).
+   * 
+   * Returns the same QueryBuilder as `query()`, but does not require any
+   * `.matchType()` or `.matchTypeAndKey()` calls before `.read()`.
+   * You can still use `.fromPosition()` and `.limit()` for pagination.
+   * 
+   * @typeParam E - Event union type for typed results
+   * @returns QueryBuilder for chaining
+   * 
+   * @example
+   * ```typescript
+   * // All events, paginated
+   * const result = await store.all().fromPosition(0n).limit(1000).read();
+   * 
+   * // All events (no filter)
+   * const result = await store.all().read();
+   * ```
+   */
+  all<E extends Event = Event>(): QueryBuilder<E> {
+    return new QueryBuilder<E>(this as unknown as QueryExecutor<E>);
+  }
+
+  /**
    * Read events matching a query
    * 
    * @typeParam E - Event union type for typed results

--- a/test/event-store.test.ts
+++ b/test/event-store.test.ts
@@ -572,5 +572,95 @@ describe('EventStore', () => {
       });
     });
 
+    describe('store.all()', () => {
+      it('returns all events across all types', async () => {
+        await store.append([
+          { type: 'CourseCreated', data: { courseId: 'cs101', name: 'CS' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+          { type: 'StudentUnsubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+        ], null);
+
+        const result = await store.all().read();
+
+        expect(result.events).toHaveLength(3);
+        expect(result.events.map(e => e.type)).toEqual([
+          'CourseCreated',
+          'StudentSubscribed',
+          'StudentUnsubscribed',
+        ]);
+      });
+
+      it('returns empty result for empty store', async () => {
+        const result = await store.all().read();
+
+        expect(result.events).toEqual([]);
+        expect(result.count).toBe(0);
+      });
+
+      it('supports fromPosition', async () => {
+        await store.append([
+          { type: 'CourseCreated', data: { courseId: 'cs101', name: 'CS' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'bob' } },
+        ], null);
+
+        const result = await store.all().fromPosition(1n).read();
+
+        expect(result.events).toHaveLength(2);
+        expect(result.events[0].type).toBe('StudentSubscribed');
+      });
+
+      it('supports limit', async () => {
+        await store.append([
+          { type: 'CourseCreated', data: { courseId: 'cs101', name: 'CS' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'bob' } },
+        ], null);
+
+        const result = await store.all().limit(2).read();
+
+        expect(result.events).toHaveLength(2);
+      });
+
+      it('supports fromPosition + limit together', async () => {
+        await store.append([
+          { type: 'CourseCreated', data: { courseId: 'cs101', name: 'CS' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'bob' } },
+          { type: 'CourseCreated', data: { courseId: 'math201', name: 'Math' } },
+        ], null);
+
+        const result = await store.all().fromPosition(1n).limit(2).read();
+
+        expect(result.events).toHaveLength(2);
+        expect(result.events[0].position).toBe(2n);
+        expect(result.events[1].position).toBe(3n);
+      });
+
+      it('appendCondition has empty failIfEventsMatch', async () => {
+        await store.append([
+          { type: 'CourseCreated', data: { courseId: 'cs101', name: 'CS' } },
+        ], null);
+
+        const result = await store.all().read();
+
+        expect(result.appendCondition).toBeDefined();
+        expect(result.appendCondition.failIfEventsMatch).toEqual([]);
+      });
+
+      it('read() with empty conditions behaves like all()', async () => {
+        await store.append([
+          { type: 'CourseCreated', data: { courseId: 'cs101', name: 'CS' } },
+          { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+        ], null);
+
+        const allResult = await store.all().read();
+        const readResult = await store.read({ conditions: [] });
+
+        expect(allResult.events).toHaveLength(readResult.events.length);
+        expect(allResult.events.map(e => e.id)).toEqual(readResult.events.map(e => e.id));
+      });
+    });
+
   });
 });

--- a/test/query-builder.test.ts
+++ b/test/query-builder.test.ts
@@ -294,3 +294,110 @@ describe('QueryBuilder — Multi-Key AND (.withKey())', () => {
     expect(fromPos.events[0].data.semester).toBe('2026-2');
   });
 });
+
+describe('store.all() — Read All Events', () => {
+  const config = {
+    eventTypes: {
+      CourseCreated: {
+        keys: [{ name: 'course', path: 'data.courseId' }]
+      },
+      StudentSubscribed: {
+        keys: [
+          { name: 'course', path: 'data.courseId' },
+          { name: 'student', path: 'data.studentId' }
+        ]
+      }
+    }
+  };
+
+  type AllEvent =
+    | Event<'CourseCreated', { courseId: string; capacity: number }>
+    | Event<'StudentSubscribed', { courseId: string; studentId: string }>;
+
+  let store: ReturnType<typeof createEventStore>;
+
+  beforeEach(async () => {
+    store = createEventStore({
+      storage: new InMemoryStorage(),
+      consistency: config
+    });
+
+    await store.append<AllEvent>([
+      { type: 'CourseCreated', data: { courseId: 'cs101', capacity: 30 } },
+      { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'alice' } },
+      { type: 'StudentSubscribed', data: { courseId: 'cs101', studentId: 'bob' } },
+      { type: 'CourseCreated', data: { courseId: 'math201', capacity: 25 } },
+      { type: 'StudentSubscribed', data: { courseId: 'math201', studentId: 'alice' } },
+    ], null);
+  });
+
+  it('returns all events without any filter', async () => {
+    const result = await store.all<AllEvent>().read();
+
+    expect(result.count).toBe(5);
+    expect(result.events.map(e => e.type)).toEqual([
+      'CourseCreated',
+      'StudentSubscribed',
+      'StudentSubscribed',
+      'CourseCreated',
+      'StudentSubscribed',
+    ]);
+  });
+
+  it('supports limit', async () => {
+    const result = await store.all<AllEvent>().limit(3).read();
+
+    expect(result.count).toBe(3);
+    expect(result.events[0].type).toBe('CourseCreated');
+    expect(result.events[2].type).toBe('StudentSubscribed');
+  });
+
+  it('supports fromPosition', async () => {
+    const allResult = await store.all<AllEvent>().read();
+    const thirdPosition = allResult.events[2].position;
+
+    const result = await store.all<AllEvent>().fromPosition(thirdPosition).read();
+
+    expect(result.count).toBe(2); // events 4 and 5
+    expect(result.events[0].type).toBe('CourseCreated');
+    expect(result.events[0].data).toEqual({ courseId: 'math201', capacity: 25 });
+  });
+
+  it('supports fromPosition + limit together', async () => {
+    const result = await store.all<AllEvent>().fromPosition(0n).limit(2).read();
+
+    expect(result.count).toBe(2);
+    expect(result.events[0].position).toBe(1n);
+    expect(result.events[1].position).toBe(2n);
+  });
+
+  it('returns empty result from empty store', async () => {
+    const emptyStore = createEventStore({
+      storage: new InMemoryStorage(),
+      consistency: config,
+    });
+
+    const result = await emptyStore.all().read();
+
+    expect(result.isEmpty()).toBe(true);
+    expect(result.count).toBe(0);
+    expect(result.events).toEqual([]);
+  });
+
+  it('appendCondition has empty failIfEventsMatch', async () => {
+    const result = await store.all<AllEvent>().read();
+
+    expect(result.appendCondition).toBeDefined();
+    expect(result.appendCondition.failIfEventsMatch).toEqual([]);
+    expect(result.appendCondition.after).toBe(5n);
+  });
+
+  it('can still chain matchType after all() (same builder)', async () => {
+    // all() returns the same QueryBuilder, so matchType still works
+    const result = await store.all<AllEvent>()
+      .matchType('CourseCreated')
+      .read();
+
+    expect(result.count).toBe(2);
+  });
+});


### PR DESCRIPTION
## What

Adds `store.all()` method that reads all events without requiring type filters. Returns the same `QueryBuilder` as `store.query()`, but doesn't require any `.matchType()` calls before `.read()`.

### API
```typescript
// All events, paginated
const result = await store.all().fromPosition(0n).limit(1000).read();

// All events (no filter)
const result = await store.all().read();
```

## Implementation

- **EventStore** (`src/event-store.ts`): Added `all()` method
- **Browser EventStore** (`src/event-store.browser.ts`): Added `all()` and `query()` methods
- All 4 storage engines already handle empty conditions correctly (no changes needed)
- No changes to exports needed (QueryBuilder already exported)

## Tests

- **174 tests pass** (21 new, 153 existing unchanged)
- Tests cover: all events, empty store, `fromPosition`, `limit`, pagination, `appendCondition`, both storage engines (InMemory + SQLite)

Closes #69