### PR TITLE
release: v0.7.0 — store.all()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to BoundlessDB will be documented in this file.
 
+## [0.7.0] - 2026-02-28
+
+### Added
+
+- **`store.all()`**: Read all events without specifying event types. Supports `.fromPosition()` and `.limit()` for pagination.
+  ```typescript
+  // All events, paginated
+  const result = await store.all().fromPosition(lastSeen).limit(1000).read();
+  
+  // All events
+  const result = await store.all().read();
+  ```
+- **`store.query()` on browser EventStore**: Was missing, now available for sql.js/in-memory usage.
+- **174 tests** (up from 153).
+
 ## [0.6.0] - 2026-02-27
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boundlessdb",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "description": "A DCB-inspired event store library for TypeScript — with support for SQLite, PostgreSQL, in-memory",
   "author": "Sebastian Bortz",


### PR DESCRIPTION
### New in v0.7.0

- **`store.all()`**: Read all events without specifying event types (#69)
- **`store.query()` on browser EventStore**: Was missing
- **174 tests** (up from 153)

### Usage
```typescript
// Paginated
const result = await store.all().fromPosition(lastSeen).limit(1000).read();

// All events
const result = await store.all().read();
```

After merge: tag `v0.7.0` → GitHub Actions publishes to npm.