### PR TITLE
fix: footer links to eventmodeling.org instead of eventstore.com

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -948,7 +948,7 @@ $ npx tsx scripts/reindex.ts --config ./consistency.ts --db ./events.sqlite
   </div>
   
   <footer>
-    <p>Built with ❤️ for <a href="https://www.eventstore.com/event-sourcing">Event Sourcing</a> · Learn more about <a href="https://dcb.events">Dynamic Consistency Boundaries</a></p>
+    <p>Built with ❤️ for Event Sourcing · Learn more about <a href="https://dcb.events">Dynamic Consistency Boundaries</a></p>
   </footer>
   
   <script>


### PR DESCRIPTION
Remove external link to eventstore.com (Kurrent) from footer. "Event Sourcing" is now plain text, no link.