### PR TITLE
release: v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to BoundlessDB will be documented in this file.
 
+## [0.12.1] - 2026-03-05
+
+### Added
+
+#### `matchTypeAndKeys()` accepts array of types
+
+Completes the DCB QueryItem model — types (OR) combined with keys (AND) in one call:
+
+```typescript
+.matchTypeAndKeys(['CourseCreated', 'CourseCancelled'], { course: 'cs101' })
+```
+
 ## [0.12.0] - 2026-03-05
 
 ### Changed (Breaking)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boundlessdb",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "MIT",
   "description": "A DCB-inspired event store library for TypeScript — with support for SQLite, PostgreSQL, in-memory",
   "author": "Sebastian Bortz",


### PR DESCRIPTION
- `matchTypeAndKeys()` accepts array of types — completes DCB QueryItem spec
- 279 tests passing